### PR TITLE
Western Europe Characters not supported.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,13 @@ In the next chapter you'll have a description for every configuration parameter.
   * `wikiDirectory` is the directory where to find additional wiki files
 	(optional; default value is `src/wiki`)
 
+
+[Jamie Townsend](http://github.com/jamietownsend) has found an issue related to character encoding on v1.0.1: 
+the plugin read markdowns with default character encoding.  
+Starting with v1.0.3, the default character encoding is `UTF-8`, but you can change
+it defining system variable `markdown.characterencoding`.
+
+
 ### <a name="usage_settings_xml_example" />settings.xml example
 
 Here you can find an example on what to add in your `${HOME}\.m2\settings.xml`.

--- a/src/main/java/confluencemavenplugin/Markdown.java
+++ b/src/main/java/confluencemavenplugin/Markdown.java
@@ -8,6 +8,8 @@ import com.github.rjeschke.txtmark.Processor;
 
 public class Markdown {
 
+	private static final String CHARACTER_ENCODING = System.getProperty("markdown.characterencoding", "UTF-8");
+	
 	private String text;
 	private File file;
 
@@ -23,7 +25,7 @@ public class Markdown {
 
 	private static Reader newReader(File file) throws FileNotFoundException {
 		try {
-			return new InputStreamReader(new FileInputStream(file), "UTF-8");
+			return new InputStreamReader(new FileInputStream(file), CHARACTER_ENCODING);
 		} catch (UnsupportedEncodingException e) {
 			throw new RuntimeException("Unable to create a Reader on file " + file + " due to an unsupported encoding", e);
 		}


### PR DESCRIPTION
During the generation phase, characters with umlauts (eg, äöü) get mangled.
